### PR TITLE
[KH-74] Kh 74/feat/redis cache guardian count

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,9 @@ dependencies {
     // Tenant-Context
     implementation 'com.doubleo:tenant-context:0.0.2'
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 dependencyManagement {

--- a/src/main/java/com/doubleo/entranceservice/domain/dto/request/EnterVerificationInfoRequest.java
+++ b/src/main/java/com/doubleo/entranceservice/domain/dto/request/EnterVerificationInfoRequest.java
@@ -13,6 +13,7 @@ public record EnterVerificationInfoRequest(
         String memberName,
         Long hospitalId,
         List<String> accessAreaCodes,
+        Long patientId,
         VisitCategory visitCategory,
         LocalDateTime startedAt,
         LocalDateTime expiredAt,

--- a/src/main/java/com/doubleo/entranceservice/domain/service/EntranceServiceImpl.java
+++ b/src/main/java/com/doubleo/entranceservice/domain/service/EntranceServiceImpl.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,7 @@ public class EntranceServiceImpl implements EntranceService {
 
     private final LogClient logClient;
     private final HospitalClient hospitalClient;
+    private final StringRedisTemplate redisTemplate;
 
     @Override
     public EnterVerificationInfoResponse verifyEntrance(
@@ -45,12 +47,28 @@ public class EntranceServiceImpl implements EntranceService {
             return new EnterVerificationInfoResponse(false, "해당 구역에는 출입 권한이 없습니다.");
         }
 
-        if (VisitCategory.GUARDIAN.equals(request.visitCategory()) && Direction.IN.equals(request.direction())) {
+        boolean isGuardianIn = VisitCategory.GUARDIAN.equals(request.visitCategory()) &&
+                Direction.IN.equals(request.direction());
+
+        boolean isGuardianOut = VisitCategory.GUARDIAN.equals(request.visitCategory()) &&
+                Direction.OUT.equals(request.direction());
+
+        String redisKey = String.format("guardian:count:%s:%s", tenantId, request.patientId());
+
+        if (isGuardianIn) {
             long maxGuardianNum = hospitalClient.getMaximumGuardianNum(tenantId);
 
-            // 현재 입장 상태인 보호자 수 임시 값 사용
-            // 입장 상태 보호자 수 snapshot table 기준으로 redis 캐싱 방식으로 수정 예정
-            long currentGuardianCount = 2;
+            String countStr = redisTemplate.opsForValue().get(redisKey);
+
+            long currentGuardianCount = 0;
+            if (countStr != null) {
+                currentGuardianCount = Long.parseLong(countStr);
+            } else {
+                // redis에 키가 없으면 0으로 간주하여 현재 보호자 수를 판단함
+                // redis 키가 없을 경우 로그 서비스에서 해당 환자의 입장 기록을 집계하여
+                // 입장 상태 보호자 수를 재계산 후 redis에 복구하는 로직이 추가 예정
+                log.info("redis에서 보호자 입장 수 데이터를 찾을 수 없어 기본값 0을 사용 redisKey={}", redisKey);
+            }
 
             if (currentGuardianCount >= maxGuardianNum) {
                 return new EnterVerificationInfoResponse(false, "최대 보호자 입장 수를 초과하였습니다.");
@@ -76,6 +94,15 @@ public class EntranceServiceImpl implements EntranceService {
                         request.passId(),
                         request.visitCategory());
             }
+
+            if (isGuardianIn) {
+                redisTemplate.opsForValue().increment(redisKey);
+            }
+
+            if (isGuardianOut) {
+                redisTemplate.opsForValue().decrement(redisKey);
+            }
+
         } catch (Exception e) {
             log.warn("출입 로그 기록 실패: {}", e.getMessage());
         }
@@ -92,4 +119,5 @@ public class EntranceServiceImpl implements EntranceService {
                                 allowed.equals(deviceAreaCode)
                                         || allowed.startsWith(deviceAreaCode + "_"));
     }
+
 }

--- a/src/main/java/com/doubleo/entranceservice/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/doubleo/entranceservice/global/config/redis/RedisConfig.java
@@ -1,0 +1,55 @@
+package com.doubleo.entranceservice.global.config.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(RedisProperties.class)
+@EnableCaching
+@Profile("!test")
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfig =
+                new RedisStandaloneConfiguration(redisProperties.host(), redisProperties.port());
+
+        if (!redisProperties.password().isBlank()) {
+            redisStandaloneConfig.setPassword(redisProperties.password());
+        }
+
+        LettuceClientConfiguration lettuceClientConfig =
+                LettuceClientConfiguration.builder()
+                        .commandTimeout(Duration.ofSeconds(30))
+                        .shutdownTimeout(Duration.ZERO)
+                        .build();
+
+        return new LettuceConnectionFactory(redisStandaloneConfig, lettuceClientConfig);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/com/doubleo/entranceservice/global/config/redis/RedisProperties.java
+++ b/src/main/java/com/doubleo/entranceservice/global/config/redis/RedisProperties.java
@@ -1,0 +1,6 @@
+package com.doubleo.entranceservice.global.config.redis;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.data.redis")
+public record RedisProperties(String host, int port, String password) {}


### PR DESCRIPTION
## 🔷 Jira Ticket ID

[KH-74]

---
## 📌 작업 내용 및 특이사항

- 환자별 보호자 입장 상태를 Redis 캐싱 방식으로 관리하도록 수정
- 출입 시 Redis 내 보호자 수를 증가 및 감소 처리 구현

---
## 📚 참고사항

-


[KH-74]: https://teamdoubleo.atlassian.net/browse/KH-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ